### PR TITLE
chore: bump peer dependencies to v17.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "typescript": "^4.3.4"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "jest": {
     "transform": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "typescript": "^4.3.4"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Since v18 is almost out figure we can bump peer deps to v17.0.2