### PR TITLE
Allow stepId to be string or number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # React Stepper
 [![Node.js CI](https://github.com/omarnyte/react-stepper/actions/workflows/test.yml/badge.svg)](https://github.com/omarnyte/react-stepper/actions/workflows/test.yml)
-
 [![npm version](https://badge.fury.io/js/@xolos%2Freact-stepper.svg)](https://badge.fury.io/js/@xolos%2Freact-stepper)
 
 A simple, flexible React step wizard hook.
@@ -44,19 +43,19 @@ export default App;
 ## API
 ```jsx
 const {
-	currentStepId,
-	currentStepIndex,
-	goToNextStep,
-	goToPreviousStep,
-	isFirstStep,
-	isLastStep
+  currentStepId,
+  currentStepIndex,
+  goToNextStep,
+  goToPreviousStep,
+  isFirstStep,
+  isLastStep
 } = useStepper(stepIds)
 ```
 ### Options
-* `stepIds: string[]`
+* `stepIds: Array<string | number>`
 
 ### Returns
-* `currentStepId: string`
+* `currentStepId: string | number`
 
 * `currentStepIndex: number`
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -3,7 +3,7 @@ import useStepper from './index';
 
 
 describe('useStepper', () => {
-	const stepIds = ['first', 'second', 'third'];
+	const stepIds = ['first', 2, 'third'];
 	
 	it('begins at first step', () => {
 		const { result } = renderHook(() => useStepper(stepIds));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-const useStepper = (stepIds: string[]) => {
+const useStepper = (stepIds: Array<string | number>) => {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
 
   const currentStepId = stepIds[currentStepIndex];


### PR DESCRIPTION
Improve API by allowing `stepIds` to be an array of strings or numbers (not just an array of strings). 